### PR TITLE
Always allow CredentialValidator to challenge

### DIFF
--- a/src/Azure.AppConfiguration.Emulator.Authentication.Anonymous/AnonymousCredentialValidator.cs
+++ b/src/Azure.AppConfiguration.Emulator.Authentication.Anonymous/AnonymousCredentialValidator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AppConfig.Service.Authentication.Anonymous
 
         public bool CanValidate(string scheme) => scheme == AuthenticationSchemes.Anonymous;
 
-        public bool CanChallenge() => _tenant.AnonymousAuthEnabled;
+        public bool CanChallenge() => true;
 
         public ValueTask<CredentialValidationResult> Validate(
             Credential credential,

--- a/src/Azure.AppConfiguration.Emulator.Authentication.EntraId/EntraIdCredentialValidator.cs
+++ b/src/Azure.AppConfiguration.Emulator.Authentication.EntraId/EntraIdCredentialValidator.cs
@@ -61,7 +61,7 @@ namespace Azure.AppConfiguration.Emulator.Authentication.EntraId
 
         public bool CanValidate(string scheme) => scheme == AuthenticationShemes.EntraId;
 
-        public bool CanChallenge() => _tenant.EntraIdAuthenticationEnabled;
+        public bool CanChallenge() => true;
 
         public async ValueTask<CredentialValidationResult> Validate(
             Credential credential,

--- a/src/Azure.AppConfiguration.Emulator.Authentication.Hmac/HmacSha256CredentialValidator.cs
+++ b/src/Azure.AppConfiguration.Emulator.Authentication.Hmac/HmacSha256CredentialValidator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AppConfig.Service.Authentication
 
         public bool CanValidate(string scheme) => scheme == AuthenticationShemes.HmacSha256;
 
-        public bool CanChallenge() => _tenant.HmacSha256Enabled;
+        public bool CanChallenge() => true;
 
         public async ValueTask<CredentialValidationResult> Validate(
             Credential credential,


### PR DESCRIPTION
## Why this bug?

Fixed the bug that when no authentication way is enabled, empty 200 response will be returned