### PR TITLE
Fix pagination bug

### DIFF
--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/KeyValueProvider.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/KeyValueProvider.cs
@@ -746,7 +746,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSettings
                 return false;
             }
 
-            string[] args = token.Split('\n', 3, StringSplitOptions.RemoveEmptyEntries);
+            string[] args = token.Split('\n', 3, StringSplitOptions.None);
 
             if (args.Length < 2)
             {


### PR DESCRIPTION
## Why this PR?

There is a bug when the continuation token has a null label. 

```C#
string[] args = token.Split('\n', 3, StringSplitOptions.RemoveEmptyEntries);
```

With `RemoveEmptyEntries` configured, null label will be discarded. And `TryParseContinuationToken` will fail [here](https://github.com/Azure/AppConfiguration-Emulator/blob/main/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/KeyValueProvider.cs#L753)

[101kv - dev.zip](https://github.com/user-attachments/files/21139130/101kv.-.dev.zip)

To reproduce the bug, the above generated 101 kvs can be helpful.
