### PR TITLE
Bug fix: IndexLookup may not include all matched item

### DIFF
--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/KeyValueProvider.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/KeyValueProvider.cs
@@ -574,37 +574,24 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSettings
 
                     foreach (string k in keys.OrderBy(x => x))
                     {
-                        int i = _cache.BinarySearch(
-                            continuationOffset,
-                            _cache.Count - continuationOffset,
-                            new KvIndex
-                            {
-                                Key = k,
-                                Label = options.LabelFilter.EqualsTo ?? options.LabelFilter.Prefix
-                            },
-                            comparer);
+                        int i = _cache.Count - continuationOffset;
 
-                        if (i < 0)
+                        while (i > 0)
                         {
-                            i = ~i;
-                        }
-                        else
-                        {
-                            // When i >= 0, binary search found an exact match
-                            // But we need to find the first item with this key to include all matches
-                            // Backtrack to find the first occurrence of the key
-                            int startIndex = i;
-                            while (startIndex > 0 && options.KeyFilter.Match(_cache[startIndex - 1].Key))
-                            {
-                                startIndex--;
-                            }
-
-                            i = startIndex;
+                            i = _cache.BinarySearch(
+                               continuationOffset,
+                               i,
+                               new KvIndex
+                               {
+                                   Key = k,
+                                   Label = options.LabelFilter.EqualsTo ?? options.LabelFilter.Prefix
+                               },
+                               comparer);
                         }
 
                         items = items.Concat(
                             _cache
-                                .Skip(i)
+                                .Skip(~i)
                                 .TakeWhile(x => options.KeyFilter.Match(x.Key)));
                     }
                 }

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/KeyValueProvider.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/KeyValueProvider.cs
@@ -588,6 +588,19 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSettings
                         {
                             i = ~i;
                         }
+                        else
+                        {
+                            // When i >= 0, binary search found an exact match
+                            // But we need to find the first item with this key to include all matches
+                            // Backtrack to find the first occurrence of the key
+                            int startIndex = i;
+                            while (startIndex > 0 && options.KeyFilter.Match(_cache[startIndex - 1].Key))
+                            {
+                                startIndex--;
+                            }
+
+                            i = startIndex;
+                        }
 
                         items = items.Concat(
                             _cache


### PR DESCRIPTION
When storage is 

```
{"ts":1752177683,"etag":"48ZZYOGCX-lefGUuBBdimA","key":"key1","label":"prod","value":"prod","rev_ttl":604800}
{"ts":1752177691,"etag":"YqTIlad2TSPouvTYVnTL6g","key":"key1","label":"dev","value":"dev","rev_ttl":604800}
{"ts":1752177740,"etag":"k90PDp77HIiAR0RI4rRWkg","key":"key2","label":"test","value":"test","rev_ttl":604800}
```

GET /kv?key=key1 will only return 

```
{
	"items": [
		{
			"etag": "48ZZYOGCX-lefGUuBBdimA",
			"key": "key1",
			"label": "prod",
			"content_type": null,
			"value": "prod",
			"tags": {},
			"locked": false,
			"last_modified": "2025-07-10T20:01:23.0213631+00:00"
		}
	]
}
```

when storage is 

```
{"ts":1752177683,"etag":"48ZZYOGCX-lefGUuBBdimA","key":"key1","label":"prod","value":"prod","rev_ttl":604800}
{"ts":1752177691,"etag":"YqTIlad2TSPouvTYVnTL6g","key":"key1","label":"dev","value":"dev","rev_ttl":604800}
```

GET /kv?key=key1 will return

```
{
	"items": [
		{
			"etag": "YqTIlad2TSPouvTYVnTL6g",
			"key": "key1",
			"label": "dev",
			"content_type": null,
			"value": "dev",
			"tags": {},
			"locked": false,
			"last_modified": "2025-07-10T20:01:31+00:00"
		},
		{
			"etag": "48ZZYOGCX-lefGUuBBdimA",
			"key": "key1",
			"label": "prod",
			"content_type": null,
			"value": "prod",
			"tags": {},
			"locked": false,
			"last_modified": "2025-07-10T20:01:23+00:00"
		}
	]
}
```