### PR TITLE
Fix content_type bug

### DIFF
--- a/src/Azure.AppConfiguration.Emulator.Service/Formatters/Json/KeyValueJsonInputFormatter.cs
+++ b/src/Azure.AppConfiguration.Emulator.Service/Formatters/Json/KeyValueJsonInputFormatter.cs
@@ -33,6 +33,7 @@ namespace Azure.AppConfiguration.Emulator.Service.Formatters.Json
         {
             return base.CanReadType(type) &&
                    (typeof(KeyValueFilterModel).IsAssignableFrom(type) ||
+                    typeof(KeyValueModel).IsAssignableFrom(type) ||
                     typeof(IEnumerable<KeyValue>).IsAssignableFrom(type));
         }
     }

--- a/src/Azure.AppConfiguration.Emulator.Service/Formatters/Json/KeyValueJsonInputFormatter.cs
+++ b/src/Azure.AppConfiguration.Emulator.Service/Formatters/Json/KeyValueJsonInputFormatter.cs
@@ -25,16 +25,12 @@ namespace Azure.AppConfiguration.Emulator.Service.Formatters.Json
             MvcNewtonsoftJsonOptions jsonOptions)
             : base(logger, serializerSettings, charPool, objectPoolProvider, options, jsonOptions)
         {
-            SupportedMediaTypes.Insert(0, MediaTypeHeaderValues.KvsApplication);
             SupportedMediaTypes.Insert(0, MediaTypeHeaderValues.KeyValueApplication);
         }
 
         protected override bool CanReadType(Type type)
         {
-            return base.CanReadType(type) &&
-                   (typeof(KeyValueFilterModel).IsAssignableFrom(type) ||
-                    typeof(KeyValueModel).IsAssignableFrom(type) ||
-                    typeof(IEnumerable<KeyValue>).IsAssignableFrom(type));
+            return base.CanReadType(type) && typeof(KeyValueModel).IsAssignableFrom(type);
         }
     }
 }


### PR DESCRIPTION
## Why this PR?

KeyValueModel is not added to `KeyValueJsonInputFormatter`. When sending PUT request, "content_type" in request body will not be recognized.