### PR TITLE
Create .aace folder in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless
 
+# Create the directory for App Configuration Emulator data so that it can be the volume mount target
+WORKDIR /app/.aace
+
 WORKDIR /app
 
 COPY publish/ .


### PR DESCRIPTION
## Why this PR?

We offered [WithDataVolume](https://github.com/dotnet/aspire/blob/main/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs#L120) API in our Aspire hosting package. The current implementation is mapping the whole `/app` folder with data volume. But it is unnecessary. Only the storage folder `/app/.aace` need to be the volume. But, mapping a volume to the container requires that the target directory exists. 

This PR creates `.aace` folder when building the image. (Previously, it is created after `Azure.AppConfiguration.Emulator.Host.dll` runs).

After, we release the new image. I will update the Aspire host package.