### PR TITLE
Snapshot Support

### DIFF
--- a/Azure.AppConfiguration.Emulator.sln
+++ b/Azure.AppConfiguration.Emulator.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31717.71
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11026.189 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.AppConfiguration.Emulator.Service", "src\Azure.AppConfiguration.Emulator.Service\Azure.AppConfiguration.Emulator.Service.csproj", "{C6DD6501-9C18-4192-9EDF-3803B06D8F63}"
 EndProject
@@ -41,6 +41,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.AppConfiguration.Emulator.ConfigurationSettings.Tests", "tests\Azure.AppConfiguration.Emulator.ConfigurationSettings.Tests\Azure.AppConfiguration.Emulator.ConfigurationSettings.Tests.csproj", "{97ADE353-F68B-4780-AC76-DE54FA06FC67}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.AppConfiguration.Emulator.Host.Tests", "tests\Azure.AppConfiguration.Emulator.Host.Tests\Azure.AppConfiguration.Emulator.Host.Tests.csproj", "{F29F948E-8FF7-495F-B44F-614DB6AC3514}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests", "tests\Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests\Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests.csproj", "{C38B618F-D69B-4BD2-A4CD-077E09D28B45}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -112,6 +114,10 @@ Global
 		{F29F948E-8FF7-495F-B44F-614DB6AC3514}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F29F948E-8FF7-495F-B44F-614DB6AC3514}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F29F948E-8FF7-495F-B44F-614DB6AC3514}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C38B618F-D69B-4BD2-A4CD-077E09D28B45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C38B618F-D69B-4BD2-A4CD-077E09D28B45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C38B618F-D69B-4BD2-A4CD-077E09D28B45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C38B618F-D69B-4BD2-A4CD-077E09D28B45}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -119,6 +125,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{97ADE353-F68B-4780-AC76-DE54FA06FC67} = {12E0AB05-317C-4C4C-B510-C596B13B7D58}
 		{F29F948E-8FF7-495F-B44F-614DB6AC3514} = {12E0AB05-317C-4C4C-B510-C596B13B7D58}
+		{C38B618F-D69B-4BD2-A4CD-077E09D28B45} = {12E0AB05-317C-4C4C-B510-C596B13B7D58}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0291B878-52BD-463B-B3B7-1D6CD5C0686B}

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/Json/JsonReaderExtensions.KeyValue.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/Json/JsonReaderExtensions.KeyValue.cs
@@ -8,7 +8,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSettings
 {
     using JsonFields = KeyValueJsonFields;
 
-    internal static partial class Utf8JsonReaderExtensions
+    public static partial class Utf8JsonReaderExtensions
     {
         public static bool TryReadKeyValue(
             this ref Utf8JsonReader reader,

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/Json/JsonReaderExtensions.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/Json/JsonReaderExtensions.cs
@@ -86,6 +86,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSettings
                     reader.TokenType == JsonTokenType.StartArray)
                 {
                     ++depth;
+
                     continue;
                 }
 
@@ -93,6 +94,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSettings
                     reader.TokenType == JsonTokenType.EndArray)
                 {
                     --depth;
+
                     continue;
                 }
             }

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/Json/JsonWriterExtensions.KeyValue.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/Json/JsonWriterExtensions.KeyValue.cs
@@ -7,7 +7,7 @@ using JsonFields = Azure.AppConfiguration.Emulator.ConfigurationSettings.KeyValu
 
 namespace Azure.AppConfiguration.Emulator.ConfigurationSettings
 {
-    internal static partial class Utf8JsonWriterExtensions
+    public static partial class Utf8JsonWriterExtensions
     {
         public static void WriteKeyValue(this Utf8JsonWriter writer, KeyValue kv)
         {

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/Json/StreamExtensions.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/Json/StreamExtensions.cs
@@ -5,7 +5,7 @@ using System.IO;
 
 namespace Azure.AppConfiguration.Emulator.ConfigurationSettings
 {
-    internal static class StreamExtensions
+    public static class StreamExtensions
     {
         private static readonly byte[] _delimiter = new byte[] { (byte)'\r', (byte)'\n' };
 

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/Storage/IKeyValueStorage.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSettings/Storage/IKeyValueStorage.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/ISnapshotProvider.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/ISnapshotProvider.cs
@@ -18,6 +18,6 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
 
         Task Recover(Snapshot snapshot, CancellationToken cancellationToken);
 
-        Task<IEnumerable<KeyValue>> GetContent(Snapshot snapshot, SnapshotContentSearchOptions options, CancellationToken cancellationToken);
+        Task<ConfigurationSettings.Page<KeyValue>> GetContent(Snapshot snapshot, SnapshotContentSearchOptions options, CancellationToken cancellationToken);
     }
 }

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Json/JsonReaderExtensions.Snapshot.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Json/JsonReaderExtensions.Snapshot.cs
@@ -1,0 +1,381 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Azure.AppConfiguration.Emulator.ConfigurationSettings;
+
+namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
+{
+    internal static class Utf8JsonReaderExtensionsSnapshot
+    {
+        public static bool TryReadSnapshot(
+            this ref Utf8JsonReader reader,
+            out Snapshot snapshot)
+        {
+            snapshot = null;
+
+            int depth = (reader.TokenType == JsonTokenType.StartObject) ? 1 : 0;
+
+            Snapshot ss = null;
+
+            while (reader.Read())
+            {
+                //
+                // Read top-level properties
+                if (depth == 1 &&
+                    reader.TokenType == JsonTokenType.PropertyName &&
+                    !reader.HasValueSequence)
+                {
+                    ss ??= new Snapshot();
+
+                    ss.SetProperty(reader.ValueSpan, ref reader);
+
+                    continue;
+                }
+
+                if (reader.TokenType == JsonTokenType.StartObject)
+                {
+                    ++depth;
+
+                    continue;
+                }
+
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    if (--depth == 0)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (depth == 0)
+            {
+                snapshot = ss;
+            }
+
+            return snapshot != null;
+        }
+
+        private static void SetProperty(
+            this Snapshot snapshot,
+            ReadOnlySpan<byte> propertyName,
+            ref Utf8JsonReader reader)
+        {
+            //
+            // id
+            if (propertyName.IsEqual(SnapshotJsonFields.Id) &&
+                reader.Read())
+            {
+                snapshot.Id = reader.GetString();
+
+                return;
+            }
+
+            //
+            // name
+            if (propertyName.IsEqual(SnapshotJsonFields.Name) &&
+                reader.Read())
+            {
+                snapshot.Name = reader.GetString();
+
+                return;
+            }
+
+            //
+            // etag
+            if (propertyName.IsEqual(SnapshotJsonFields.Etag) &&
+                reader.Read())
+            {
+                snapshot.Etag = reader.GetString();
+
+                return;
+            }
+
+            //
+            // status
+            if (propertyName.IsEqual(SnapshotJsonFields.Status) &&
+                reader.Read())
+            {
+                snapshot.Status = ParseStatus(reader.GetString());
+
+                return;
+            }
+
+            //
+            // status_code
+            if (propertyName.IsEqual(SnapshotJsonFields.StatusCode) &&
+                reader.Read())
+            {
+                snapshot.StatusCode = reader.GetInt32();
+
+                return;
+            }
+
+            //
+            // composition_type
+            if (propertyName.IsEqual(SnapshotJsonFields.CompositionType) &&
+                reader.Read() &&
+                reader.TokenType == JsonTokenType.String)
+            {
+                snapshot.CompositionType = ParseCompositionType(reader.GetString());
+
+                return;
+            }
+
+            //
+            // retention_period_seconds
+            if (propertyName.IsEqual(SnapshotJsonFields.RetentionPeriodSeconds) &&
+                reader.Read())
+            {
+                snapshot.RetentionPeriod = TimeSpan.FromSeconds(reader.GetInt64());
+
+                return;
+            }
+
+            //
+            // created
+            if (propertyName.IsEqual(SnapshotJsonFields.Created) &&
+                reader.Read())
+            {
+                snapshot.Created = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+
+                return;
+            }
+
+            //
+            // last_modified
+            if (propertyName.IsEqual(SnapshotJsonFields.LastModified) &&
+                reader.Read())
+            {
+                snapshot.LastModified = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+
+                return;
+            }
+
+            //
+            // expires
+            if (propertyName.IsEqual(SnapshotJsonFields.Expires) &&
+                reader.Read())
+            {
+                snapshot.Expires = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+                return;
+            }
+
+            //
+            // items_count
+            if (propertyName.IsEqual(SnapshotJsonFields.ItemsCount) &&
+                reader.Read())
+            {
+                snapshot.ItemCount = reader.GetInt64();
+
+                return;
+            }
+
+            //
+            // size_bytes
+            if (propertyName.IsEqual(SnapshotJsonFields.SizeBytes) &&
+                reader.Read())
+            {
+                snapshot.Size = reader.GetInt64();
+
+                return;
+            }
+
+            //
+            // tags
+            if (propertyName.IsEqual(SnapshotJsonFields.Tags) &&
+                reader.Read())
+            {
+                snapshot.Tags = reader.ReadDictionary();
+
+                return;
+            }
+
+            //
+            // filters
+            if (propertyName.IsEqual(SnapshotJsonFields.Filters) &&
+                reader.Read() &&
+                reader.TokenType == JsonTokenType.StartArray)
+            {
+                var filters = new List<KeyValueFilter>();
+
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.StartObject)
+                    {
+                        string key = null;
+
+                        string label = null;
+
+                        while (reader.Read())
+                        {
+                            if (reader.TokenType == JsonTokenType.PropertyName && !reader.HasValueSequence)
+                            {
+                                ReadOnlySpan<byte> pn = reader.ValueSpan;
+
+                                if (pn.IsEqual(SnapshotJsonFields.Key) &&
+                                    reader.Read())
+                                {
+                                    key = reader.GetString();
+
+                                    continue;
+                                }
+
+                                if (pn.IsEqual(SnapshotJsonFields.Label) &&
+                                    reader.Read())
+                                {
+                                    label = reader.GetString();
+
+                                    continue;
+                                }
+                            }
+
+                            if (reader.TokenType == JsonTokenType.EndObject)
+                            {
+                                break;
+                            }
+                        }
+
+                        filters.Add(new KeyValueFilter { Key = key, Label = label });
+                    }
+
+                    if (reader.TokenType == JsonTokenType.EndArray)
+                    {
+                        break;
+                    }
+                }
+
+                snapshot.Filters = filters;
+
+                return;
+            }
+
+            //
+            // media
+            if (propertyName.IsEqual(SnapshotJsonFields.Media) &&
+                reader.Read() &&
+                reader.TokenType == JsonTokenType.StartObject)
+            {
+                MediaInfo media = new MediaInfo();
+
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.PropertyName && !reader.HasValueSequence)
+                    {
+                        ReadOnlySpan<byte> pn = reader.ValueSpan;
+
+                        //
+                        // category
+                        if (pn.IsEqual(SnapshotJsonFields.Category) &&
+                            reader.Read())
+                        {
+                            media.Category = reader.GetString();
+
+                            continue;
+                        }
+
+                        //
+                        // media name
+                        if (pn.IsEqual(SnapshotJsonFields.MediaName) &&
+                            reader.Read())
+                        {
+                            media.Name = reader.GetString();
+
+                            continue;
+                        }
+
+                        //
+                        // media size
+                        if (pn.IsEqual(SnapshotJsonFields.MediaSize) &&
+                            reader.Read())
+                        {
+                            media.Size = reader.GetInt64();
+
+                            continue;
+                        }
+
+                        //
+                        // etag
+                        if (pn.IsEqual(SnapshotJsonFields.Etag) &&
+                            reader.Read())
+                        {
+                            media.Etag = reader.GetString();
+                            continue;
+                        }
+
+                        //
+                        // content_type
+                        if (pn.IsEqual(SnapshotJsonFields.ContentType) &&
+                            reader.Read())
+                        {
+                            media.ContentType = reader.GetString();
+                            continue;
+                        }
+
+                        //
+                        // sha256
+                        if (pn.IsEqual(SnapshotJsonFields.Sha256) &&
+                            reader.Read())
+                        {
+                            media.Sha256Hash = DecodeBase64Url(reader.GetString());
+                            continue;
+                        }
+                    }
+
+                    if (reader.TokenType == JsonTokenType.EndObject)
+                    {
+                        break;
+                    }
+                }
+
+                snapshot.Media = media;
+                return;
+            }
+        }
+
+        private static SnapshotStatus ParseStatus(string value) => value switch
+        {
+            "provisioning" => SnapshotStatus.Provisioning,
+            "ready" => SnapshotStatus.Ready,
+            "archived" => SnapshotStatus.Archived,
+            "failed" => SnapshotStatus.Failed,
+            _ => SnapshotStatus.Provisioning
+        };
+
+        private static CompositionType ParseCompositionType(string value) => value switch
+        {
+            "key" => CompositionType.Key,
+            "key_label" => CompositionType.KeyLabel,
+            _ => CompositionType.Key
+        };
+
+        private static byte[] DecodeBase64Url(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+
+            string base64 = value.Replace('-', '+').Replace('_', '/');
+
+            int pad = base64.Length % 4;
+
+            if (pad > 0)
+            {
+                base64 = base64 + new string('=', 4 - pad);
+            }
+
+            try
+            {
+                return Convert.FromBase64String(base64);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Json/JsonReaderExtensions.Snapshot.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Json/JsonReaderExtensions.Snapshot.cs
@@ -161,6 +161,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
                 reader.Read())
             {
                 snapshot.Expires = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+
                 return;
             }
 
@@ -303,6 +304,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
                             reader.Read())
                         {
                             media.Etag = reader.GetString();
+
                             continue;
                         }
 
@@ -312,6 +314,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
                             reader.Read())
                         {
                             media.ContentType = reader.GetString();
+
                             continue;
                         }
 
@@ -321,6 +324,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
                             reader.Read())
                         {
                             media.Sha256Hash = DecodeBase64Url(reader.GetString());
+
                             continue;
                         }
                     }

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Json/JsonWriterExtensions.Snapshot.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Json/JsonWriterExtensions.Snapshot.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Text.Json;
+using Azure.AppConfiguration.Emulator.ConfigurationSettings;
+
+namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
+{
+    internal static class Utf8JsonWriterExtensionsSnapshot
+    {
+        public static void WriteSnapshot(this Utf8JsonWriter writer, Snapshot snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            writer.WriteStartObject();
+
+            //
+            // id
+            if (snapshot.Id != null)
+            {
+                writer.WriteString(SnapshotJsonFields.Id, snapshot.Id);
+            }
+
+            //
+            // name
+            if (snapshot.Name != null)
+            {
+                writer.WriteString(SnapshotJsonFields.Name, snapshot.Name);
+            }
+
+            //
+            // etag
+            if (snapshot.Etag != null)
+            {
+                writer.WriteString(SnapshotJsonFields.Etag, snapshot.Etag);
+            }
+
+            //
+            // status
+            writer.WriteString(SnapshotJsonFields.Status, ToStatus(snapshot.Status));
+
+            //
+            // status_code
+            writer.WriteNumber(SnapshotJsonFields.StatusCode, snapshot.StatusCode);
+
+            //
+            // composition_type
+            writer.WriteString(SnapshotJsonFields.CompositionType, ToCompositionType(snapshot.CompositionType));
+
+            //
+            // retention_period_seconds
+            writer.WriteNumber(SnapshotJsonFields.RetentionPeriodSeconds, (long)snapshot.RetentionPeriod.TotalSeconds);
+
+            //
+            // created
+            writer.WriteNumber(SnapshotJsonFields.Created, snapshot.Created.ToUnixTimeSeconds());
+
+            //
+            // last_modified
+            writer.WriteNumber(SnapshotJsonFields.LastModified, snapshot.LastModified.ToUnixTimeSeconds());
+
+            //
+            // expires
+            if (snapshot.Expires.HasValue)
+            {
+                writer.WriteNumber(SnapshotJsonFields.Expires, snapshot.Expires.Value.ToUnixTimeSeconds());
+            }
+
+            //
+            // items_count
+            writer.WriteNumber(SnapshotJsonFields.ItemsCount, snapshot.ItemCount);
+
+            //
+            // size_bytes
+            writer.WriteNumber(SnapshotJsonFields.SizeBytes, snapshot.Size);
+
+            //
+            // tags
+            if (snapshot.Tags != null)
+            {
+                writer.WriteDictionary(SnapshotJsonFields.Tags, snapshot.Tags);
+            }
+
+            //
+            // filters
+            if (snapshot.Filters != null)
+            {
+                writer.WriteStartArray(SnapshotJsonFields.Filters);
+                foreach (KeyValueFilter f in snapshot.Filters)
+                {
+                    if (f != null)
+                    {
+                        writer.WriteStartObject();
+                        if (f.Key != null)
+                        {
+                            writer.WriteString(SnapshotJsonFields.Key, f.Key);
+                        }
+
+                        if (f.Label != null)
+                        {
+                            writer.WriteString(SnapshotJsonFields.Label, f.Label);
+                        }
+
+                        writer.WriteEndObject();
+                    }
+                }
+
+                writer.WriteEndArray();
+            }
+
+            //
+            // media
+            if (snapshot.Media != null)
+            {
+                writer.WriteStartObject(SnapshotJsonFields.Media);
+
+                if (snapshot.Media.Category != null)
+                {
+                    writer.WriteString(SnapshotJsonFields.Category, snapshot.Media.Category);
+                }
+
+                if (snapshot.Media.Name != null)
+                {
+                    writer.WriteString(SnapshotJsonFields.MediaName, snapshot.Media.Name);
+                }
+
+                writer.WriteNumber(SnapshotJsonFields.MediaSize, snapshot.Media.Size);
+
+                if (snapshot.Media.Etag != null)
+                {
+                    writer.WriteString(SnapshotJsonFields.Etag, snapshot.Media.Etag);
+                }
+
+                if (snapshot.Media.ContentType != null)
+                {
+                    writer.WriteString(SnapshotJsonFields.ContentType, snapshot.Media.ContentType);
+                }
+
+                if (snapshot.Media.Sha256Hash != null)
+                {
+                    writer.WriteString(SnapshotJsonFields.Sha256, Base64UrlEncoding.Encode(snapshot.Media.Sha256Hash));
+                }
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndObject();
+        }
+
+        private static string ToStatus(SnapshotStatus status) => status switch
+        {
+            SnapshotStatus.Provisioning => "provisioning",
+            SnapshotStatus.Ready => "ready",
+            SnapshotStatus.Archived => "archived",
+            SnapshotStatus.Failed => "failed",
+            _ => "provisioning"
+        };
+
+        private static string ToCompositionType(CompositionType type) => type switch
+        {
+            CompositionType.Key => "key",
+            CompositionType.KeyLabel => "key_label",
+            _ => "key"
+        };
+    }
+}

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Json/SnapshotJsonFields.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Json/SnapshotJsonFields.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Text.Json;
+
+namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
+{
+    internal static class SnapshotJsonFields
+    {
+        public static readonly JsonEncodedText Id = JsonEncodedText.Encode("id");
+        public static readonly JsonEncodedText Name = JsonEncodedText.Encode("name");
+        public static readonly JsonEncodedText Etag = JsonEncodedText.Encode("etag");
+        public static readonly JsonEncodedText Status = JsonEncodedText.Encode("status");
+        public static readonly JsonEncodedText StatusCode = JsonEncodedText.Encode("status_code");
+        public static readonly JsonEncodedText CompositionType = JsonEncodedText.Encode("composition_type");
+        public static readonly JsonEncodedText RetentionPeriodSeconds = JsonEncodedText.Encode("retention_period_seconds");
+        public static readonly JsonEncodedText Created = JsonEncodedText.Encode("created");
+        public static readonly JsonEncodedText LastModified = JsonEncodedText.Encode("last_modified");
+        public static readonly JsonEncodedText Expires = JsonEncodedText.Encode("expires");
+        public static readonly JsonEncodedText ItemsCount = JsonEncodedText.Encode("items_count");
+        public static readonly JsonEncodedText SizeBytes = JsonEncodedText.Encode("size_bytes");
+        public static readonly JsonEncodedText Tags = JsonEncodedText.Encode("tags");
+        public static readonly JsonEncodedText Filters = JsonEncodedText.Encode("filters");
+        public static readonly JsonEncodedText Media = JsonEncodedText.Encode("media");
+        public static readonly JsonEncodedText Category = JsonEncodedText.Encode("category");
+        public static readonly JsonEncodedText MediaName = JsonEncodedText.Encode("name");
+        public static readonly JsonEncodedText MediaSize = JsonEncodedText.Encode("size");
+        public static readonly JsonEncodedText ContentType = JsonEncodedText.Encode("content_type");
+        public static readonly JsonEncodedText Sha256 = JsonEncodedText.Encode("sha256");
+        public static readonly JsonEncodedText Key = JsonEncodedText.Encode("key");
+        public static readonly JsonEncodedText Label = JsonEncodedText.Encode("label");
+    }
+}

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/SnapshotProviderOptions.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/SnapshotProviderOptions.cs
@@ -35,11 +35,11 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
         /// <summary>
         /// Minimum filter count
         /// </summary>
-        public int MinFilterCount { get; set; }
+        public int MinFilterCount { get; set; } = 1;
 
         /// <summary>
         /// Maximum filter count
         /// </summary>
-        public int MaxFilterCount { get; set; }
+        public int MaxFilterCount { get; set; } = 3;
     }
 }

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Storage/ISnapshotContentsStorge.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Storage/ISnapshotContentsStorge.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Azure.AppConfiguration.Emulator.ConfigurationSettings;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
+{
+    public interface ISnapshotContentsStorage
+    {
+        Task<MediaInfo> CreateContent(string fileName, IEnumerable<KeyValue> items, CancellationToken cancellationToken);
+
+        IAsyncEnumerable<KeyValue> GetContent(MediaInfo media, long offset, CancellationToken cancellationToken);
+    }
+}

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Storage/ISnapshotsStorage.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Storage/ISnapshotsStorage.cs
@@ -10,7 +10,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
 {
     public interface ISnapshotsStorage
     {
-        IAsyncEnumerable<Snapshot> QuerySnapshots();
+        IAsyncEnumerable<Snapshot> QuerySnapshots(CancellationToken cancellationToken);
 
         Task<Snapshot> GetSnapshot(string snapshotId, CancellationToken cancellationToken);
 

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Storage/ISnapshotsStorage.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Storage/ISnapshotsStorage.cs
@@ -18,6 +18,6 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
 
         Task UpdateSnapshot(Snapshot snapshot, CancellationToken cancellationToken);
 
-        IAsyncEnumerable<KeyValue> ReadSnapshotContent(Snapshot snapshot, long offset);
+        Task RemoveSnapshots(IEnumerable<Snapshot> snapshots, CancellationToken cancellationToken);
     }
 }

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Storage/SnapshotsStorage.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Storage/SnapshotsStorage.cs
@@ -2,59 +2,167 @@
 // Licensed under the MIT license.
 
 using Azure.AppConfiguration.Emulator.ConfigurationSettings;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
 {
-    public class SnapshotsStorage : ISnapshotsStorage
+    public class SnapshotsStorage : ISnapshotsStorage, ISnapshotContentsStorage
     {
-        private readonly SnapshotProviderOptions _options;
+        private readonly SnapshotProviderOptions _providerOptions;
+        private readonly SnapshotsStorageOptions _options;
+        private readonly string _metadataFilePath;
+        private readonly string _contentDirectory;
 
-        public SnapshotsStorage(IOptions<SnapshotProviderOptions> options)
+        public SnapshotsStorage(
+            IOptions<SnapshotProviderOptions> providerOptions,
+            IOptions<SnapshotsStorageOptions> options,
+            IHostingEnvironment host)
         {
+            _providerOptions = providerOptions?.Value ?? throw new ArgumentNullException(nameof(providerOptions));
             _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+
+            ValidateOptions(_options);
+
+            _metadataFilePath = _options.MetadataFilePath;
+            if (!Path.IsPathRooted(_metadataFilePath))
+            {
+                _metadataFilePath = Path.Combine(host.ContentRootPath, _metadataFilePath);
+            }
+
+            _metadataFilePath = Path.GetFullPath(_metadataFilePath);
+
+            InsureFileExist(_metadataFilePath);
+
+            string directory = _options.ContentDirectory;
+            if (!Path.IsPathRooted(directory))
+            {
+                directory = Path.Combine(host.ContentRootPath, directory);
+            }
+
+            directory = Path.GetFullPath(directory);
+            _contentDirectory = directory;
+
+            EnsureDirectory(_contentDirectory);
+        }
+
+        public async IAsyncEnumerable<Snapshot> QuerySnapshots(
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            if (!File.Exists(_metadataFilePath))
+            {
+                yield break;
+            }
+
+            using var fs = new FileStream(
+                _metadataFilePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read);
+
+            var reader = new NdJsonStreamReader<Snapshot>(
+                fs,
+                (ref Utf8JsonReader r, out Snapshot s) => r.TryReadSnapshot(out s),
+                _options.ReadBufferSizeHint,
+                _options.MaxReadBufferSize);
+
+            using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(_options.ReadTimeout);
+
+            await using IAsyncEnumerator<Snapshot> e = reader.ReadItems(cts.Token).GetAsyncEnumerator();
+
+            while (true)
+            {
+                Snapshot current = null;
+
+                try
+                {
+                    if (!await e.MoveNextAsync(cts.Token))
+                    {
+                        yield break;
+                    }
+
+                    current = e.Current;
+                }
+                catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+                {
+                    throw new TimeoutException("QuerySnapshots", ex);
+                }
+
+                if (current != null)
+                {
+                    yield return current;
+                }
+            }
         }
 
         public IAsyncEnumerable<Snapshot> QuerySnapshots()
         {
-            //
-            // TODO: Add implementation
-            //
-
-            return AsyncEnumerable.Empty<Snapshot>();
+            return QuerySnapshots(CancellationToken.None);
         }
 
-        public Task<Snapshot> GetSnapshot(string snapshotId, CancellationToken cancellationToken)
+        public async Task<Snapshot> GetSnapshot(string snapshotId, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(snapshotId))
             {
                 throw new ArgumentNullException(nameof(snapshotId));
             }
 
-            //
-            // TODO: Add implementation
-            //
+            await foreach (var s in QuerySnapshots(cancellationToken))
+            {
+                if (s.Id == snapshotId)
+                {
+                    return s;
+                }
+            }
 
-            return Task.FromResult<Snapshot>(null);
+            return null;
         }
 
-        public Task AddSnapshot(Snapshot snapshot, CancellationToken cancellationToken)
+        public async Task AddSnapshot(Snapshot snapshot, CancellationToken cancellationToken)
         {
             ValidateSnapshot(snapshot);
 
-            //
-            // TODO: Add implementation
-            //
+            using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(_options.WriteTimeout);
 
-            return Task.CompletedTask;
+            using var fs = new FileStream(
+                _metadataFilePath,
+                FileMode.Append,
+                FileAccess.Write,
+                FileShare.Read,
+                _options.AppendBufferSize);
+
+            if (fs.Position > 0)
+            {
+                fs.WriteDelimiter();
+            }
+
+            using var json = new Utf8JsonWriter(fs);
+            json.WriteSnapshot(snapshot);
+
+            try
+            {
+                await json.FlushAsync(cts.Token);
+                await fs.FlushAsync(cts.Token);
+            }
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException("AddSnapshot", ex);
+            }
         }
 
-        public Task UpdateSnapshot(Snapshot snapshot, CancellationToken cancellationToken)
+        public async Task UpdateSnapshot(Snapshot snapshot, CancellationToken cancellationToken)
         {
             ValidateSnapshot(snapshot);
 
@@ -63,22 +171,224 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
                 throw new ArgumentNullException(nameof(snapshot.Etag));
             }
 
-            //
-            // TODO: Add implementation
-            //
+            string tempFilePath = _metadataFilePath + ".tmp";
 
-            return Task.CompletedTask;
+            try
+            {
+                using var fs = new FileStream(
+                    tempFilePath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.None,
+                    _options.WriteBufferSize);
+
+                using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(_options.WriteTimeout);
+
+                await foreach (var s in QuerySnapshots(cts.Token))
+                {
+                    if (fs.Position > 0)
+                    {
+                        fs.WriteDelimiter();
+                    }
+
+                    using var json = new Utf8JsonWriter(fs);
+                    json.WriteSnapshot(s.Id == snapshot.Id ? snapshot : s);
+                    await json.FlushAsync(cts.Token);
+                }
+
+                await fs.FlushAsync(cts.Token);
+            }
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException("UpdateSnapshot", ex);
+            }
+
+            ReplaceFile(tempFilePath, _metadataFilePath);
         }
 
-        public IAsyncEnumerable<KeyValue> ReadSnapshotContent(Snapshot snapshot, long offset)
+        public async Task<MediaInfo> CreateContent(string fileName, IEnumerable<KeyValue> items, CancellationToken cancellationToken)
         {
-            ValidateSnapshot(snapshot);
+            if (string.IsNullOrEmpty(fileName))
+            {
+                throw new ArgumentNullException(nameof(fileName));
+            }
 
-            //
-            // TODO: Add implementation
-            //
+            if (items == null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
 
-            return AsyncEnumerable.Empty<KeyValue>();
+            string targetFilePath = Path.Combine(_contentDirectory, fileName);
+            string tempFilePath = targetFilePath + ".tmp";
+
+            MediaInfo media = new MediaInfo
+            {
+                Category = "snapshots",
+                ContentType = "application/x-ndjson"
+            };
+
+            try
+            {
+                using FileStream fs = new FileStream(
+                    tempFilePath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.None,
+                    _options.WriteBufferSize);
+
+                using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(_options.WriteTimeout);
+
+                foreach (KeyValue kv in items)
+                {
+                    if (fs.Position > 0)
+                    {
+                        fs.WriteDelimiter();
+                    }
+
+                    using Utf8JsonWriter json = new Utf8JsonWriter(fs);
+                    json.WriteKeyValue(kv);
+                    await json.FlushAsync(cts.Token);
+                }
+
+                await fs.FlushAsync(cts.Token);
+            }
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException("ProvisionSnapshotContent", ex);
+            }
+
+            ReplaceFile(tempFilePath, targetFilePath);
+
+            long fileSizeBytes = new FileInfo(targetFilePath).Length;
+
+            media.Name = Path.GetFileName(targetFilePath);
+            media.Size = fileSizeBytes;
+            media.Etag = SnapshotHelper.GenerateEtag();
+            media.Sha256Hash = ComputeSha256(targetFilePath);
+
+            return media;
+        }
+
+        public async IAsyncEnumerable<KeyValue> GetContent(MediaInfo media, long offset, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            if (media == null)
+            {
+                throw new ArgumentNullException(nameof(media));
+            }
+
+            if (string.IsNullOrEmpty(media.Name))
+            {
+                yield break;
+            }
+
+            string filePath = Path.Combine(_contentDirectory, media.Name);
+
+            if (!File.Exists(filePath))
+            {
+                yield break;
+            }
+
+            using FileStream fs = new FileStream(
+                filePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read);
+
+            NdJsonStreamReader<KeyValue> reader = new NdJsonStreamReader<KeyValue>(
+                fs,
+                (ref Utf8JsonReader r, out KeyValue kv) => r.TryReadKeyValue(out kv),
+                _options.ReadBufferSizeHint,
+                _options.MaxReadBufferSize);
+
+            using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(_options.ReadTimeout);
+
+            long index = 0;
+
+            await foreach (KeyValue kv in reader.ReadItems(cts.Token))
+            {
+                if (index++ < offset)
+                {
+                    continue;
+                }
+
+                yield return kv;
+            }
+        }
+
+        public async Task RemoveSnapshots(IEnumerable<Snapshot> snapshots, CancellationToken cancellationToken)
+        {
+            if (snapshots == null)
+            {
+                throw new ArgumentNullException(nameof(snapshots));
+            }
+
+            var toRemove = snapshots.Select(s => s.Id).ToHashSet();
+
+            string tempFilePath = _metadataFilePath + ".tmp";
+
+            try
+            {
+                using var fs = new FileStream(
+                    tempFilePath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.None,
+                    _options.WriteBufferSize);
+
+                using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(_options.WriteTimeout);
+
+                await foreach (var s in QuerySnapshots(cts.Token))
+                {
+                    if (s == null)
+                    {
+                        continue;
+                    }
+
+                    if (toRemove.Contains(s.Id))
+                    {
+                        // Delete content file if exists
+                        if (s.Media?.Name != null)
+                        {
+                            string path = Path.Combine(_contentDirectory, s.Media.Name);
+
+                            if (File.Exists(path))
+                            {
+                                try
+                                {
+                                    File.Delete(path);
+                                }
+                                catch
+                                {
+                                    // ignore file delete errors
+                                }
+                            }
+                        }
+
+                        continue;
+                    }
+
+                    if (fs.Position > 0)
+                    {
+                        fs.WriteDelimiter();
+                    }
+
+                    using var json = new Utf8JsonWriter(fs);
+                    json.WriteSnapshot(s);
+                    await json.FlushAsync(cts.Token);
+                }
+
+                await fs.FlushAsync(cts.Token);
+            }
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException("RemoveSnapshots", ex);
+            }
+
+            ReplaceFile(tempFilePath, _metadataFilePath);
         }
 
         private static void ValidateSnapshot(Snapshot snapshot)
@@ -91,6 +401,112 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
             if (string.IsNullOrEmpty(snapshot.Id))
             {
                 throw new ArgumentNullException(nameof(snapshot.Id));
+            }
+        }
+
+        private void ValidateOptions(SnapshotsStorageOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (string.IsNullOrEmpty(options.MetadataFilePath))
+            {
+                throw new ArgumentNullException(nameof(options.MetadataFilePath));
+            }
+
+            if (string.IsNullOrEmpty(options.ContentDirectory))
+            {
+                throw new ArgumentNullException(nameof(options.ContentDirectory));
+            }
+
+            if (options.AppendBufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options.AppendBufferSize));
+            }
+
+            if (options.WriteBufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options.WriteBufferSize));
+            }
+
+            if (options.MaxReadBufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options.MaxReadBufferSize));
+            }
+
+            if (options.ReadBufferSizeHint <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options.ReadBufferSizeHint));
+            }
+
+            if (options.ReadTimeout <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options.ReadTimeout));
+            }
+
+            if (options.WriteTimeout <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options.WriteTimeout));
+            }
+        }
+
+        private static void InsureFileExist(string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath));
+
+            if (File.Exists(filePath))
+            {
+                return;
+            }
+
+            string directoryPath = Path.GetDirectoryName(filePath);
+
+            if (!string.IsNullOrEmpty(directoryPath) && !Directory.Exists(directoryPath))
+            {
+                _ = Directory.CreateDirectory(directoryPath);
+            }
+
+            using FileStream fs = new FileStream(filePath, FileMode.Append);
+            using StreamWriter writer = new StreamWriter(fs);
+        }
+
+        private static void ReplaceFile(string tempFilePath, string targetFilePath)
+        {
+            if (File.Exists(targetFilePath))
+            {
+                string bakFilePath = targetFilePath + ".bac";
+                File.Replace(tempFilePath, targetFilePath, bakFilePath);
+
+                if (File.Exists(bakFilePath))
+                {
+                    File.Delete(bakFilePath);
+                }
+            }
+            else
+            {
+                File.Move(tempFilePath, targetFilePath);
+            }
+
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+            }
+        }
+
+        private static byte[] ComputeSha256(string filePath)
+        {
+            using FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using SHA256 sha = SHA256.Create();
+            return sha.ComputeHash(fs);
+        }
+
+        private static void EnsureDirectory(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
             }
         }
     }

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Storage/SnapshotsStorage.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Storage/SnapshotsStorage.cs
@@ -17,7 +17,9 @@ using System.Threading.Tasks;
 
 namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
 {
-    public class SnapshotsStorage : ISnapshotsStorage, ISnapshotContentsStorage
+    public class SnapshotsStorage :
+        ISnapshotsStorage,
+        ISnapshotContentsStorage
     {
         private readonly SnapshotProviderOptions _providerOptions;
         private readonly SnapshotsStorageOptions _options;
@@ -106,12 +108,9 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
             }
         }
 
-        public IAsyncEnumerable<Snapshot> QuerySnapshots()
-        {
-            return QuerySnapshots(CancellationToken.None);
-        }
-
-        public async Task<Snapshot> GetSnapshot(string snapshotId, CancellationToken cancellationToken)
+        public async Task<Snapshot> GetSnapshot(
+            string snapshotId,
+            CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(snapshotId))
             {
@@ -129,7 +128,9 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
             return null;
         }
 
-        public async Task AddSnapshot(Snapshot snapshot, CancellationToken cancellationToken)
+        public async Task AddSnapshot(
+            Snapshot snapshot,
+            CancellationToken cancellationToken)
         {
             ValidateSnapshot(snapshot);
 
@@ -162,7 +163,9 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
             }
         }
 
-        public async Task UpdateSnapshot(Snapshot snapshot, CancellationToken cancellationToken)
+        public async Task UpdateSnapshot(
+            Snapshot snapshot,
+            CancellationToken cancellationToken)
         {
             ValidateSnapshot(snapshot);
 
@@ -207,7 +210,10 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
             ReplaceFile(tempFilePath, _metadataFilePath);
         }
 
-        public async Task<MediaInfo> CreateContent(string fileName, IEnumerable<KeyValue> items, CancellationToken cancellationToken)
+        public async Task<MediaInfo> CreateContent(
+            string fileName,
+            IEnumerable<KeyValue> items,
+            CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(fileName))
             {
@@ -271,7 +277,10 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
             return media;
         }
 
-        public async IAsyncEnumerable<KeyValue> GetContent(MediaInfo media, long offset, [EnumeratorCancellation] CancellationToken cancellationToken)
+        public async IAsyncEnumerable<KeyValue> GetContent(
+            MediaInfo media,
+            long offset,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             if (media == null)
             {
@@ -318,7 +327,9 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
             }
         }
 
-        public async Task RemoveSnapshots(IEnumerable<Snapshot> snapshots, CancellationToken cancellationToken)
+        public async Task RemoveSnapshots(
+            IEnumerable<Snapshot> snapshots,
+            CancellationToken cancellationToken)
         {
             if (snapshots == null)
             {
@@ -479,6 +490,8 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
                 string bakFilePath = targetFilePath + ".bac";
                 File.Replace(tempFilePath, targetFilePath, bakFilePath);
 
+                //
+                // Clean up the bak file
                 if (File.Exists(bakFilePath))
                 {
                     File.Delete(bakFilePath);
@@ -486,9 +499,13 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
             }
             else
             {
+                //
+                // Rename the temporary file to the original file
                 File.Move(tempFilePath, targetFilePath);
             }
 
+            //
+            // Clean up the temporary file
             if (File.Exists(tempFilePath))
             {
                 File.Delete(tempFilePath);

--- a/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Storage/SnapshotsStorageOptions.cs
+++ b/src/Azure.AppConfiguration.Emulator.ConfigurationSnapshots/Storage/SnapshotsStorageOptions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+
+namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots
+{
+    public class SnapshotsStorageOptions
+    {
+        public string MetadataFilePath { get; set; } = ".aace/snapshot.ndjson";
+
+        public string ContentDirectory { get; set; } = ".aace/snapshots";
+
+        public int AppendBufferSize { get; set; } = 8 * 1024; // bytes
+
+        public int WriteBufferSize { get; set; } = 1_000_000; // bytes
+
+        public int ReadBufferSizeHint { get; set; } = 32 * 1024; // bytes
+
+        public int MaxReadBufferSize { get; set; } = 1_000_000; // bytes
+
+        public TimeSpan ReadTimeout { get; set; } = TimeSpan.FromSeconds(120);
+
+        public TimeSpan WriteTimeout { get; set; } = TimeSpan.FromSeconds(120);
+    }
+}

--- a/src/Azure.AppConfiguration.Emulator.Integration/ServiceCollectionExtensions.cs
+++ b/src/Azure.AppConfiguration.Emulator.Integration/ServiceCollectionExtensions.cs
@@ -68,8 +68,12 @@ namespace Azure.AppConfiguration.Emulator.Integration
 
         public static IServiceCollection AddConfigurationSnapshots(this IServiceCollection services)
         {
-            services.TryAddSingleton<ISnapshotsStorage, SnapshotsStorage>();
-            services.TryAddSingleton<ISnapshotProvider, SnapshotProvider>();
+            services.TryAddSingleton<SnapshotsStorage>();
+            services.TryAddSingleton<ISnapshotsStorage>(sp => sp.GetRequiredService<SnapshotsStorage>());
+            services.TryAddSingleton<ISnapshotContentsStorage>(sp => sp.GetRequiredService<SnapshotsStorage>());
+            services.TryAddSingleton<SnapshotProvider>();
+            services.TryAddSingleton<ISnapshotProvider>(sp => sp.GetRequiredService<SnapshotProvider>());
+            services.AddHostedService(sp => sp.GetRequiredService<SnapshotProvider>());
 
             return services;
         }

--- a/src/Azure.AppConfiguration.Emulator.Service/Formatters/Json/SnapshotJsonOutputFormatter.cs
+++ b/src/Azure.AppConfiguration.Emulator.Service/Formatters/Json/SnapshotJsonOutputFormatter.cs
@@ -76,11 +76,8 @@ namespace Azure.AppConfiguration.Emulator.Service.Formatters.Json
 
             SnapshotFields fields = request.GetSnapshotFields();
 
-            // Avoid disposing HttpResponseStreamWriter as it performs synchronous writes on Dispose.
-            TextWriter writer = ctx.WriterFactory(response.Body, selectedEncoding);
-            JsonWriter jw = CreateJsonWriter(writer);
-
-            try
+            using (var writer = ctx.WriterFactory(response.Body, selectedEncoding))
+            using (JsonWriter jw = CreateJsonWriter(writer))
             {
                 await serializer.WriteContent(
                     jw,
@@ -89,12 +86,6 @@ namespace Azure.AppConfiguration.Emulator.Service.Formatters.Json
 
                 // Explicitly use AsyncFlush to do async write. Otherwise it will be sync
                 await writer.FlushAsync();
-            }
-            finally
-            {
-                // Do not dispose the writer to avoid sync IO in Dispose path.
-                // Close the JsonWriter to release buffers if needed.
-                jw.Close();
             }
         }
 

--- a/src/Azure.AppConfiguration.Emulator.Tenant/TenantOptions.cs
+++ b/src/Azure.AppConfiguration.Emulator.Tenant/TenantOptions.cs
@@ -16,7 +16,7 @@ namespace Azure.AppConfiguration.Emulator.Tenant
 
         public string ResourceGroup { get; init; }
 
-        public string ResourceId { get; init; }
+        public string ResourceId { get; init; } = "emulator";
 
         public IEnumerable<AccessKey> AccessKeys { get; init; }
 

--- a/tests/Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests/Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests.csproj
+++ b/tests/Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests/Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Moq" Version="4.20.69" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Azure.AppConfiguration.Emulator.ConfigurationSnapshots\Azure.AppConfiguration.Emulator.ConfigurationSnapshots.csproj" />
+    <ProjectReference Include="..\..\src\Azure.AppConfiguration.Emulator.ConfigurationSettings\Azure.AppConfiguration.Emulator.ConfigurationSettings.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests/SnapshotsStorageTests.cs
+++ b/tests/Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests/SnapshotsStorageTests.cs
@@ -1,0 +1,229 @@
+using Azure.AppConfiguration.Emulator.ConfigurationSettings;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests
+{
+    public class SnapshotsStorageTests : IDisposable
+    {
+        private readonly string _metadataPath;
+        private readonly string _contentDir;
+        private readonly Mock<IHostingEnvironment> _env;
+        private readonly SnapshotsStorage _storage;
+
+        public SnapshotsStorageTests()
+        {
+            var testDir = Path.GetDirectoryName(typeof(SnapshotsStorageTests).Assembly.Location) ?? Directory.GetCurrentDirectory();
+            _metadataPath = Path.Combine(Path.GetTempPath(), $"snap_meta_unit_{Guid.NewGuid()}.ndjson");
+            _contentDir = Path.Combine(Path.GetTempPath(), $"snap_content_unit_{Guid.NewGuid()}");
+            _env = new Mock<IHostingEnvironment>();
+            _env.Setup(e => e.ContentRootPath).Returns(testDir);
+
+            var storageOptions = new SnapshotsStorageOptions
+            {
+                MetadataFilePath = _metadataPath,
+                ContentDirectory = _contentDir,
+                WriteBufferSize = 8192,
+                AppendBufferSize = 4096,
+                ReadBufferSizeHint = 4096,
+                MaxReadBufferSize = 65536,
+                ReadTimeout = TimeSpan.FromSeconds(5),
+                WriteTimeout = TimeSpan.FromSeconds(5)
+            };
+            var providerOptions = new SnapshotProviderOptions
+            {
+                OutputPageSize = 100,
+                ReadTimeout = TimeSpan.FromSeconds(5),
+                WriteTimeout = TimeSpan.FromSeconds(5),
+                RetryTimeout = TimeSpan.FromSeconds(5),
+                ConflictRetryTimeout = TimeSpan.FromSeconds(5),
+                MinFilterCount = 1,
+                MaxFilterCount = 100
+            };
+
+            _storage = new SnapshotsStorage(
+                Options.Create(providerOptions),
+                Options.Create(storageOptions),
+                _env.Object);
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(_metadataPath))
+            {
+                File.Delete(_metadataPath);
+            }
+
+            if (Directory.Exists(_contentDir))
+            {
+                Directory.Delete(_contentDir, true);
+            }
+
+            var tmp = _metadataPath + ".tmp";
+            if (File.Exists(tmp))
+            {
+                File.Delete(tmp);
+            }
+
+            var bak = _metadataPath + ".bac";
+            if (File.Exists(bak))
+            {
+                File.Delete(bak);
+            }
+        }
+
+        [Fact]
+        public async Task AddSnapshot_PersistsEntry()
+        {
+            var snapshot = NewSnapshot("snap-add-1");
+            await _storage.AddSnapshot(snapshot, CancellationToken.None);
+
+            var list = await _storage.QuerySnapshots().ToListAsync();
+
+            Assert.Single(list);
+            Assert.Equal("snap-add-1", list[0].Id);
+            Assert.Equal(SnapshotStatus.Ready, list[0].Status);
+        }
+
+        [Fact]
+        public async Task UpdateSnapshot_ReplacesExistingEntry()
+        {
+            var snapshot = NewSnapshot("snap-upd-1");
+            await _storage.AddSnapshot(snapshot, CancellationToken.None);
+
+            snapshot.ItemCount = 5;
+            snapshot.Size = 1234;
+            snapshot.Etag = $"etag-{Guid.NewGuid():N}";
+            snapshot.LastModified = DateTimeOffset.UtcNow;
+            await _storage.UpdateSnapshot(snapshot, CancellationToken.None);
+
+            var list = await _storage.QuerySnapshots().ToListAsync();
+            var stored = list.Single(s => s.Id == snapshot.Id);
+
+            Assert.Equal(5, stored.ItemCount);
+            Assert.Equal(1234, stored.Size);
+        }
+
+        [Fact]
+        public async Task QuerySnapshots_ReturnsAll()
+        {
+            var a = NewSnapshot("snap-q-1");
+            var b = NewSnapshot("snap-q-2");
+            await _storage.AddSnapshot(a, CancellationToken.None);
+            await _storage.AddSnapshot(b, CancellationToken.None);
+
+            var ids = await _storage.QuerySnapshots().Select(s => s.Id).ToListAsync();
+
+            Assert.Contains("snap-q-1", ids);
+            Assert.Contains("snap-q-2", ids);
+            Assert.Equal(2, ids.Count);
+        }
+
+        [Fact]
+        public async Task CreateContent_WritesFile_AndReturnsMediaInfo()
+        {
+            Directory.CreateDirectory(_contentDir);
+            string fileName = "snapA.ndjson";
+            string filePath = Path.Combine(_contentDir, fileName);
+            var items = new List<KeyValue>
+            {
+                new KeyValue { Key = "k1", Label = "l1", Value = "v1" },
+                new KeyValue { Key = "k2", Label = "l2", Value = "v2" }
+            };
+
+            MediaInfo media = await _storage.CreateContent(fileName, items, CancellationToken.None);
+
+            Assert.NotNull(media);
+            Assert.Equal("snapshots", media.Category);
+            Assert.Equal("application/x-ndjson", media.ContentType);
+            Assert.Equal(fileName, media.Name);
+            Assert.True(File.Exists(filePath));
+            long physicalSize = new FileInfo(filePath).Length;
+            Assert.Equal(physicalSize, media.Size);
+            Assert.False(string.IsNullOrEmpty(media.Etag));
+            Assert.NotNull(media.Sha256Hash);
+        }
+
+        [Fact]
+        public async Task GetContent_ReturnsItems_FromOffset()
+        {
+            Directory.CreateDirectory(_contentDir);
+            string fileName = "snapB.ndjson";
+            var items = new List<KeyValue>
+            {
+                new KeyValue { Key = "k1", Label = "l1", Value = "v1" },
+                new KeyValue { Key = "k2", Label = "l2", Value = "v2" },
+                new KeyValue { Key = "k3", Label = "l3", Value = "v3" }
+            };
+
+            MediaInfo media = await _storage.CreateContent(fileName, items, CancellationToken.None);
+
+            var fromSecond = new List<KeyValue>();
+            await foreach (var kv in _storage.GetContent(media, 1, CancellationToken.None))
+            {
+                fromSecond.Add(kv);
+            }
+
+            Assert.Equal(2, fromSecond.Count);
+            Assert.Equal("k2", fromSecond[0].Key);
+            Assert.Equal("k3", fromSecond[1].Key);
+        }
+
+        [Fact]
+        public async Task GetContent_WithInvalidMedia_ReturnsEmpty()
+        {
+            var empty = new List<KeyValue>();
+            await foreach (var kv in _storage.GetContent(new MediaInfo { Name = null }, 0, CancellationToken.None))
+            {
+                empty.Add(kv);
+            }
+
+            Assert.Empty(empty);
+        }
+
+        [Fact]
+        public async Task RemoveSnapshots_RemovesMetadataAndDeletesContent()
+        {
+            Directory.CreateDirectory(_contentDir);
+
+            var snapA = NewSnapshot("snapA");
+            snapA.Media = await _storage.CreateContent("snapA.ndjson", new[] { new KeyValue { Key = "k1", Label = "l1", Value = "v1" } }, CancellationToken.None);
+            snapA.ItemCount = 1;
+            snapA.Size = snapA.Media.Size;
+
+            var snapB = NewSnapshot("snapB");
+            snapB.Media = await _storage.CreateContent("snapB.ndjson", new[] { new KeyValue { Key = "k2", Label = "l2", Value = "v2" } }, CancellationToken.None);
+            snapB.ItemCount = 1;
+            snapB.Size = snapB.Media.Size;
+
+            await _storage.AddSnapshot(snapA, CancellationToken.None);
+            await _storage.AddSnapshot(snapB, CancellationToken.None);
+
+            Assert.True(File.Exists(Path.Combine(_contentDir, snapA.Media.Name)));
+            Assert.True(File.Exists(Path.Combine(_contentDir, snapB.Media.Name)));
+
+            await _storage.RemoveSnapshots(new[] { snapA }, CancellationToken.None);
+
+            var all = await _storage.QuerySnapshots().ToListAsync();
+            Assert.DoesNotContain(all, s => s.Id == "snapA");
+            Assert.Contains(all, s => s.Id == "snapB");
+
+            Assert.False(File.Exists(Path.Combine(_contentDir, snapA.Media.Name)));
+            Assert.True(File.Exists(Path.Combine(_contentDir, snapB.Media.Name)));
+        }
+
+        private static Snapshot NewSnapshot(string id) => new Snapshot
+        {
+            Id = id,
+            Name = id,
+            Etag = $"etag-{Guid.NewGuid():N}",
+            Status = SnapshotStatus.Ready,
+            CompositionType = CompositionType.Key,
+            RetentionPeriod = TimeSpan.FromMinutes(30),
+            Created = DateTimeOffset.UtcNow,
+            LastModified = DateTimeOffset.UtcNow,
+            Filters = new[] { new KeyValueFilter { Key = "k", Label = "l" } }
+        };
+    }
+}

--- a/tests/Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests/SnapshotsStorageTests.cs
+++ b/tests/Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests/SnapshotsStorageTests.cs
@@ -79,7 +79,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests
             var snapshot = NewSnapshot("snap-add-1");
             await _storage.AddSnapshot(snapshot, CancellationToken.None);
 
-            var list = await _storage.QuerySnapshots().ToListAsync();
+            var list = await _storage.QuerySnapshots(CancellationToken.None).ToListAsync();
 
             Assert.Single(list);
             Assert.Equal("snap-add-1", list[0].Id);
@@ -98,7 +98,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests
             snapshot.LastModified = DateTimeOffset.UtcNow;
             await _storage.UpdateSnapshot(snapshot, CancellationToken.None);
 
-            var list = await _storage.QuerySnapshots().ToListAsync();
+            var list = await _storage.QuerySnapshots(CancellationToken.None).ToListAsync();
             var stored = list.Single(s => s.Id == snapshot.Id);
 
             Assert.Equal(5, stored.ItemCount);
@@ -113,7 +113,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests
             await _storage.AddSnapshot(a, CancellationToken.None);
             await _storage.AddSnapshot(b, CancellationToken.None);
 
-            var ids = await _storage.QuerySnapshots().Select(s => s.Id).ToListAsync();
+            var ids = await _storage.QuerySnapshots(CancellationToken.None).Select(s => s.Id).ToListAsync();
 
             Assert.Contains("snap-q-1", ids);
             Assert.Contains("snap-q-2", ids);
@@ -205,7 +205,7 @@ namespace Azure.AppConfiguration.Emulator.ConfigurationSnapshots.Tests
 
             await _storage.RemoveSnapshots(new[] { snapA }, CancellationToken.None);
 
-            var all = await _storage.QuerySnapshots().ToListAsync();
+            var all = await _storage.QuerySnapshots(CancellationToken.None).ToListAsync();
             Assert.DoesNotContain(all, s => s.Id == "snapA");
             Assert.Contains(all, s => s.Id == "snapB");
 

--- a/tests/Azure.AppConfiguration.Emulator.Host.Tests/SnapshotTests.cs
+++ b/tests/Azure.AppConfiguration.Emulator.Host.Tests/SnapshotTests.cs
@@ -1,0 +1,85 @@
+﻿using Xunit;
+using System.Text;
+using System.Text.Json;
+
+namespace Azure.AppConfiguration.Emulator.Host.Tests
+{
+    [Collection("TestServerCollection")]
+    public class SnapshotTests
+    {
+        private readonly ITestServer _testServer;
+        private const string ApiVersion = "2024-09-01";
+
+        public SnapshotTests(TestServerFixture fixture)
+        {
+            _testServer = fixture.TestServer;
+        }
+
+        [Fact]
+        public async Task CreateSnapshot_ReturnsReady_AndContent()
+        {
+            var client = _testServer.Client;
+
+            var key1 = "snap-key-1";
+            var key2 = "snap-key-2";
+            await TestHelpers.CreateKeyValue(client, key1, "v1", label: "dev");
+            await TestHelpers.CreateKeyValue(client, key2, "v2", label: "prod");
+
+            var snapshotName = "snapshot-host-test";
+            var snapshotBody = new
+            {
+                composition_type = "key",
+                filters = new[]
+                {
+                    new { key = key1, label = "dev" },
+                    new { key = key2, label = "prod" }
+                }
+            };
+
+            var json = JsonSerializer.Serialize(snapshotBody);
+            var content = new StringContent(json, Encoding.UTF8, "application/vnd.microsoft.appconfig.snapshot+json");
+            var putResponse = await client.PutAsync($"/snapshots/{snapshotName}?api-version={ApiVersion}", content);
+
+            Assert.Equal(System.Net.HttpStatusCode.Created, putResponse.StatusCode);
+
+            var getResponse = await client.GetAsync($"/snapshots/{snapshotName}?api-version={ApiVersion}");
+            var getContent = await getResponse.Content.ReadAsStringAsync();
+            Assert.Contains("\"status\":\"ready\"", getContent);
+
+            var kvPage = await client.GetAsync($"/kv?snapshot={snapshotName}&api-version={ApiVersion}");
+            kvPage.EnsureSuccessStatusCode();
+            var kvJson = await kvPage.Content.ReadAsStringAsync();
+            Assert.Contains(key1, kvJson);
+            Assert.Contains(key2, kvJson);
+        }
+
+        [Fact]
+        public async Task CreateSnapshot_ExistingName_ReturnsConflict()
+        {
+            var client = _testServer.Client;
+
+            var snapshotName = "snapshot-conflict";
+            var body = new
+            {
+                composition_type = "key",
+                filters = new[]
+                {
+                    new { key = "conflict-key", label = (string)null }
+                }
+            };
+
+            var json = JsonSerializer.Serialize(body);
+            var content = new StringContent(json, Encoding.UTF8, "application/vnd.microsoft.appconfig.snapshot+json");
+            var first = await client.PutAsync($"/snapshots/{snapshotName}?api-version={ApiVersion}", content);
+            Assert.Equal(System.Net.HttpStatusCode.Created, first.StatusCode);
+
+            // Second PUT with same name should return 409 problem+json
+            var second = await client.PutAsync($"/snapshots/{snapshotName}?api-version={ApiVersion}", content);
+            Assert.Equal(System.Net.HttpStatusCode.Conflict, second.StatusCode);
+            Assert.Equal("application/problem+json", second.Content.Headers.ContentType?.MediaType);
+
+            var err = await second.Content.ReadAsStringAsync();
+            Assert.Contains("already-exists", err);
+        }
+    }
+}

--- a/tests/Azure.AppConfiguration.Emulator.Host.Tests/TestServer.cs
+++ b/tests/Azure.AppConfiguration.Emulator.Host.Tests/TestServer.cs
@@ -32,12 +32,26 @@ namespace Azure.AppConfiguration.Emulator.Host.Tests
             string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
 
             string storageDirectory = Path.Combine(baseDirectory, ".aace");
-            string storageFilePath = Path.Combine(storageDirectory, "kv.ndjson");
+            string kvFilePath = Path.Combine(storageDirectory, "kv.ndjson");
+            string snapshotFilePath = Path.Combine(storageDirectory, "snapshot.ndjson");
+            string snapshotFolderPath = Path.Combine(storageDirectory, "snapshots");
 
-            if (File.Exists(storageFilePath))
+            if (File.Exists(kvFilePath))
             {
-                File.Delete(storageFilePath);
-                Console.WriteLine($"Deleted storage file: {storageFilePath}");
+                File.Delete(kvFilePath);
+                Console.WriteLine($"Deleted storage file: {kvFilePath}");
+            }
+
+            if (File.Exists(snapshotFilePath))
+            {
+                File.Delete(snapshotFilePath);
+                Console.WriteLine($"Deleted storage file: {snapshotFilePath}");
+            }
+
+            if (Directory.Exists(snapshotFolderPath))
+            {
+                Directory.Delete(snapshotFolderPath, true);
+                Console.WriteLine($"Deleted storage directory: {snapshotFolderPath}");
             }
         }
 
@@ -73,6 +87,8 @@ namespace Azure.AppConfiguration.Emulator.Host.Tests
 
         public void Dispose()
         {
+            DeleteStorageFile();
+
             _httpClient?.Dispose();
             _server?.Dispose();
         }


### PR DESCRIPTION
## Why this PR?
Support the [snapshot](https://learn.microsoft.com/en-us/azure/azure-app-configuration/rest-api-snapshot?pivots=v23-11) APIs.

### Snapshot storage

- Metadata: All snapshot metadata persisted as newline-delimited JSON records in .aace/snapshot.ndjson. New snapshot uses Append; update/remove rewrites whole file via temp file + atomic Replace.
- Content: Each snapshot’s captured key-values serialized as NDJSON into its own file (snapshotId.ndjson) under  .aace/snapshots folder. 

### Snapshot management

- Provision: On snapshot Create, the emulator immediately gathers matching key-values, writes the content NDJSON file, computes media info (size, hash, etag), and then appends the snapshot metadata in one flow. A successful PUT request returns a snapshot already in Ready state (no intermediate Provisioning state). This is different from the async provision behavior of the real App Config service.
- Clean up (lazy deletion): Purge only runs once, triggered inside SnapshotProvider.EnsureInit after loading metadata cache. (Different from KeyValueProvider's periodic cleanup logic)